### PR TITLE
Jaswanth | Split liquibase changeset with preconditions

### DIFF
--- a/atomfeed-client/src/main/resources/sql/db_migrations.xml
+++ b/atomfeed-client/src/main/resources/sql/db_migrations.xml
@@ -32,15 +32,25 @@
             <column name="title" type="varchar(255)"></column>
         </addColumn>
     </changeSet>
-    <changeSet id="102" author="Sudhakar, Abishek">
-        <validCheckSum>3:b5cc640e5bdcf23514b3fc1a6c73d25f</validCheckSum>
+    <changeSet id="102-1" author="Jaswanth">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <columnExists tableName="failed_events" columnName="retries" schemaName="${schemaName}"/>
+            </not>
+        </preConditions>
         <addColumn tableName="failed_events" schemaName="${schemaName}" >
             <column name="retries" type="int"
                     defaultValueNumeric="0">
                 <constraints nullable="false"/>
             </column>
         </addColumn>
-
+    </changeSet>
+    <changeSet id="102-2" author="Jaswanth">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <tableExists tableName="failed_event_retry_log" schemaName="${schemaName}"/>
+            </not>
+        </preConditions>
         <createTable tableName="failed_event_retry_log" schemaName="${schemaName}">
             <column name="id" type="serial">
                 <constraints nullable="false" primaryKey="true"/>


### PR DESCRIPTION
There was a failure related to this changeset in pacs-integration app :
**1 change sets check sum
          classpath:sql/db_migrations.xml::102::Sudhakar, Abishek is now: 7:d64c93e5819c867f1ed2ba5cc17832f2**

Upon some analysis, it is found that pacs was using liquibase 3.4.0. This particular changeset was first run on CI machines in July. It had the recomputed the checksum for version 3.4.0 as **7:6f9c4493a58c5389542c8b597fac3e9d**. But, it is failing in CI now.