### PR TITLE
BAH-4291 | Fix. Remove Sonatype OSS dependency as parent

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,12 +13,6 @@
         <jetty.version>8.1.8.v20121106</jetty.version>
     </properties>
 
-    <parent>
-        <groupId>org.sonatype.oss</groupId>
-        <artifactId>oss-parent</artifactId>
-        <version>7</version>
-    </parent>
-
 
     <licenses>
         <license>


### PR DESCRIPTION
This PR removes the parent configuration for Sonatype publish configuration